### PR TITLE
mdl master 72321  mustache core_question to qbank_managecategories 382

### DIFF
--- a/question/bank/managecategories/classes/category_condition.php
+++ b/question/bank/managecategories/classes/category_condition.php
@@ -126,7 +126,7 @@ class category_condition extends condition {
         if ($this->category) {
             $displaydata['categorydesc'] = $this->print_category_info($this->category);
         }
-        return $PAGE->get_renderer('core_question', 'bank')->render_category_condition($displaydata);
+        return $PAGE->get_renderer('qbank_managecategories')->render_category_condition($displaydata);
     }
 
     /**
@@ -139,7 +139,7 @@ class category_condition extends condition {
         if ($this->recurse) {
             $displaydata['checked'] = 'checked="true"';
         }
-        return $PAGE->get_renderer('core_question', 'bank')->render_category_condition_advanced($displaydata);
+        return $PAGE->get_renderer('qbank_managecategories')->render_category_condition_advanced($displaydata);
     }
 
     /**

--- a/question/bank/managecategories/classes/output/renderer.php
+++ b/question/bank/managecategories/classes/output/renderer.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qbank_managecategories\output;
+
+use plugin_renderer_base;
+
+/**
+ * Class renderer for managecategories.
+ *
+ * @package    qbank_managecategories
+ * @copyright  2021 Catalyst IT Australia Pty Ltd
+ * @author     Ghaly Marc-Alexandre <marc-alexandreghaly@catalyst-ca.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class renderer extends plugin_renderer_base {
+    /**
+     * Render category condition advanced.
+     *
+     * @param array $displaydata
+     * @return bool|string
+     */
+    public function render_category_condition_advanced($displaydata) {
+        return $this->render_from_template('qbank_managecategories/category_condition_advanced', $displaydata);
+    }
+
+    /**
+     * Render category condition.
+     *
+     * @param array $displaydata
+     * @return bool|string
+     */
+    public function render_category_condition($displaydata) {
+        return $this->render_from_template('qbank_managecategories/category_condition', $displaydata);
+    }
+}

--- a/question/bank/managecategories/templates/category_condition.mustache
+++ b/question/bank/managecategories/templates/category_condition.mustache
@@ -15,19 +15,24 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template core_question/category_condition_advanced
+    @template qbank_managecategories/category_condition
 
     Example context (json):
     {
         "displaydata": [
           {
-                "checked": "checked attribute"
+                "categoryselect": "html string",
+                "categorydesc": "html string"
           }
         ]
     }
 }}
-<div class="category_condition_advanced">
-    <input type="hidden" name="recurse" value="0" id="recurse_off">
-    <input id="recurse_on" class="searchoptions mr-1" type="checkbox" value="1" name="recurse" {{{checked}}}>
-    <label for="recurse_on">{{#str}} includesubcategories, question{{/str}}</label>
+<div class="choosecategory">
+    <label class="mr-1" for="id_selectacategory">
+        {{#str}} selectacategory, question{{/str}}
+    </label>
+    {{{categoryselect}}}
+</div>
+<div class="boxaligncenter categoryinfo pl-0">
+    {{{categorydesc}}}
 </div>

--- a/question/bank/managecategories/templates/category_condition_advanced.mustache
+++ b/question/bank/managecategories/templates/category_condition_advanced.mustache
@@ -15,24 +15,19 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template core_question/category_condition
+    @template qbank_managecategories/category_condition_advanced
 
     Example context (json):
     {
         "displaydata": [
           {
-                "categoryselect": "html string",
-                "categorydesc": "html string"
+                "checked": "checked attribute"
           }
         ]
     }
 }}
-<div class="choosecategory">
-    <label class="mr-1" for="id_selectacategory">
-        {{#str}} selectacategory, question{{/str}}
-    </label>
-    {{{categoryselect}}}
-</div>
-<div class="boxaligncenter categoryinfo pl-0">
-    {{{categorydesc}}}
+<div class="category_condition_advanced">
+    <input type="hidden" name="recurse" value="0" id="recurse_off">
+    <input id="recurse_on" class="searchoptions mr-1" type="checkbox" value="1" name="recurse" {{{checked}}}>
+    <label for="recurse_on">{{#str}} includesubcategories, question{{/str}}</label>
 </div>

--- a/question/renderer.php
+++ b/question/renderer.php
@@ -107,26 +107,6 @@ class core_question_bank_renderer extends plugin_renderer_base {
     }
 
     /**
-     * Render category condition.
-     *
-     * @param array $displaydata
-     * @return bool|string
-     */
-    public function render_category_condition($displaydata) {
-        return $this->render_from_template('core_question/category_condition', $displaydata);
-    }
-
-    /**
-     * Render category condition advanced.
-     *
-     * @param array $displaydata
-     * @return bool|string
-     */
-    public function render_category_condition_advanced($displaydata) {
-        return $this->render_from_template('core_question/category_condition_advanced', $displaydata);
-    }
-
-    /**
      * Render hidden condition advanced.
      *
      * @param array $displaydata


### PR DESCRIPTION
Hi @safatshahin, I moved both `category_condition` and `category_condition_advanced` mustaches to the qbank_managecategories. Added a renderer as well, but I can't see the `category_condition` being called in the view, only the advanced one. This PR is for issue #382.

Thank you
