### PR TITLE
Question bank table columns fixes #402

### DIFF
--- a/mod/quiz/styles.css
+++ b/mod/quiz/styles.css
@@ -909,10 +909,6 @@ table#categoryquestions {
     padding: 0;
 }
 
-#categoryquestions .editmenu {
-    width: 5em;
-}
-
 #categoryquestions .qtype {
     text-align: center;
 }

--- a/question/classes/local/bank/column_base.php
+++ b/question/classes/local/bank/column_base.php
@@ -101,6 +101,7 @@ abstract class column_base {
         $data = [];
         $data['sortable'] = true;
         $data['extraclasses'] = $this->get_classes();
+        $data['style'] = $this->get_styles();
         $sortable = $this->is_sortable();
         $name = get_class($this);
         $title = $this->get_title();
@@ -142,6 +143,16 @@ abstract class column_base {
      * @return string a fuller version of the name.
      */
     protected function get_title_tip() {
+        return '';
+    }
+
+    /**
+     * Use this when get_styles() returns
+     * some style property to put into the th and td tags.
+     *
+     * @return string a string to put into a style="" property
+     */
+    protected function get_styles() {
         return '';
     }
 
@@ -216,7 +227,7 @@ abstract class column_base {
      */
     protected function display_start($question, $rowclasses): void {
         $tag = 'td';
-        $attr = ['class' => $this->get_classes()];
+        $attr = ['class' => $this->get_classes(), 'style' => $this->get_styles()];
         if ($this->isheading) {
             $tag = 'th';
             $attr['scope'] = 'row';

--- a/question/classes/local/bank/edit_menu_column.php
+++ b/question/classes/local/bank/edit_menu_column.php
@@ -72,6 +72,10 @@ class edit_menu_column extends column_base {
         return 'editmenu';
     }
 
+    public function get_styles(): string {
+        return "width: " . (mb_strlen(get_string('edit'), 'UTF-8') + 1) . "em;";
+    }
+
     protected function display_content($question, $rowclasses): void {
         global $OUTPUT;
 

--- a/question/templates/column_header.mustache
+++ b/question/templates/column_header.mustache
@@ -26,12 +26,13 @@
                 "tiptitle": "Element title",
                 "sorttip": true,
                 "tip": "Select questions for bulk actions",
-                "sortlinks": "sort / sort"
+                "sortlinks": "sort / sort",
+                "style": "width: 5em;"
           }
         ]
     }
 }}
-<th class="header {{extraclasses}}" scope="col">
+<th class="header {{extraclasses}}" scope="col"{{#style}} style="{{style}}"{{/style}}>
     {{#title}}
         <div class="title">{{title}}</div>
     {{/title}}


### PR DESCRIPTION
I really saw no other possibility to deal with that, since I struggeled to come up with a style sheet solution only.

My 'solution' goes and counts the length of the 'Edit' string, then outputting that to a style = "width:XXem;" property of the th and td container. Although this might not be that ideal, such injecting a element with a width style is done in other parts in Moodle, too.
Note this is [MDL-67123](https://tracker.moodle.org/browse/MDL-67123) and [MDL-69811](https://tracker.moodle.org/browse/MDL-69811).

Please let me know what you think.